### PR TITLE
feat(home): Display rewards balance and progress

### DIFF
--- a/assets/icons/chevron-down.svg
+++ b/assets/icons/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="ionicon" viewBox="0 0 512 512">
+    <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="M112 184l144 144 144-144"/>
+</svg>

--- a/assets/icons/chevron-up.svg
+++ b/assets/icons/chevron-up.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="ionicon" viewBox="0 0 512 512">
+    <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="48" d="M112 328l144-144 144 144"/>
+</svg>

--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -5,5 +5,5 @@ import { Button } from './Button';
 test('Correctly renders button', async () => {
   render(<Button text="Press me" />);
 
-  expect(await screen.findByText('Press me')).toBeOnTheScreen();
+  expect(await screen.findByRole('button', { name: 'Press me' })).toBeOnTheScreen();
 });

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -10,7 +10,7 @@ interface ButtonProps extends PressableProps {
 
 export const Button = (buttonProps: ButtonProps) => {
   return (
-    <Pressable style={[styles.pillButton, buttonProps.buttonStyle]}>
+    <Pressable role="button" style={[styles.pillButton, buttonProps.buttonStyle]}>
       <Text style={[styles.text, buttonProps.textStyle]}>{buttonProps.text}</Text>
     </Pressable>
   );

--- a/src/components/ProgressBar.test.tsx
+++ b/src/components/ProgressBar.test.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { ProgressBar } from './ProgressBar';
+
+test('Correctly renders progress br', async () => {
+  render(<ProgressBar progress={0.5} />);
+
+  expect(await screen.findByRole('progressbar', { name: 'Points progress' })).toBeOnTheScreen();
+});
+
+test('Correctly renders progress bar with tiers', async () => {
+  render(<ProgressBar progress={0.5} tiers={[50, 100, 150]} />);
+
+  expect(await screen.findByRole('progressbar', { name: 'Points progress' })).toBeOnTheScreen();
+  expect(await screen.findByText('50')).toBeOnTheScreen();
+  expect(await screen.findByText('100')).toBeOnTheScreen();
+  expect(await screen.findByText('150')).toBeOnTheScreen();
+});

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { colors } from '../theme/colors';
+import { fonts } from '../theme/typography';
+
+interface ProgressBarProps {
+  /**
+   * Progress value (between 0 and 1).
+   */
+  progress: number;
+  /*
+   * Levels to display under progress bar (optional)
+   */
+  tiers?: number[];
+}
+
+export const ProgressBar = (props: ProgressBarProps) => {
+  const progress = props.progress;
+  const tiers = props.tiers ?? [];
+
+  const getWidth = (index: number) => {
+    if (index === 0) {
+      return 10;
+    }
+    if (index === tiers.length) {
+      return ((450 - tiers[tiers.length - 1]) / 450) * 100;
+    }
+    return ((tiers[index] - tiers[index - 1]) / 450) * 100;
+  };
+
+  return (
+    <View>
+      <View accessible accessibilityRole="progressbar" accessibilityLabel="Points progress" style={styles.container}>
+        <View accessibilityLabel="" style={[styles.bar, { width: `${progress * 100}%` }]} />
+      </View>
+      {tiers && (
+        <View style={styles.tiers}>
+          {tiers.map((tier, index) => {
+            return (
+              <Text key={tier} style={[styles.tier, { width: `${getWidth(index)}%` }]}>
+                {tier}
+              </Text>
+            );
+          })}
+          <Text style={[styles.tier, { width: `${getWidth(tiers.length)}%` }]} />
+        </View>
+      )}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    height: 8,
+    backgroundColor: '#ccc',
+    borderRadius: 10,
+  },
+  bar: {
+    height: 8,
+    backgroundColor: colors.accentGreen,
+    borderRadius: 10,
+  },
+  tiers: {
+    flexDirection: 'row',
+    alignItems: 'stretch',
+    justifyContent: 'center',
+    alignSelf: 'stretch',
+    paddingTop: 3,
+  },
+  tier: {
+    fontSize: 12,
+    color: colors.neutral500,
+    fontFamily: fonts.SodoSans.semibold,
+    textAlign: 'right',
+  },
+});

--- a/src/screens/home/Home.test.tsx
+++ b/src/screens/home/Home.test.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { getProgress, Home } from './Home';
+
+describe('getProgress', () => {
+  test('Returns value if value less than 1', () => {
+    expect(getProgress(0, 5)).toBe(0);
+    expect(getProgress(3, 5)).toBe(0.6);
+    expect(getProgress(99, 100)).toBe(0.99);
+    expect(getProgress(5, 5)).toBe(1);
+  });
+
+  test('Returns 1 if value is greater than 1', () => {
+    expect(getProgress(10, 5)).toBe(1);
+  });
+
+  test('Returns 0 if value is negative', () => {
+    expect(getProgress(-5, 10)).toBe(0);
+  });
+
+  test('Returns 0 if maxPoints is 0', () => {
+    expect(getProgress(5, 0)).toBe(0);
+  });
+});
+
+test('Correctly renders screen', async () => {
+  render(<Home />);
+
+  expect(await screen.findByText('Star balance')).toBeOnTheScreen();
+  expect(await screen.findByText('Rewards options')).toBeOnTheScreen();
+  expect(await screen.findByRole('progressbar')).toBeOnTheScreen();
+  expect(await screen.findByRole('button', { name: 'Details' })).toBeOnTheScreen();
+});
+
+test('Correctly shows and hides Rewards options', async () => {
+  render(<Home />);
+
+  expect(screen.queryByText('Rewards you can get with points')).not.toBeOnTheScreen();
+
+  fireEvent.press(await screen.findByText('Rewards options'));
+  expect(await screen.findByText('Rewards you can get with points')).toBeOnTheScreen();
+
+  fireEvent.press(await screen.findByText('Rewards options'));
+  expect(screen.queryByText('Rewards you can get with points')).not.toBeOnTheScreen();
+});

--- a/src/screens/home/Home.tsx
+++ b/src/screens/home/Home.tsx
@@ -1,13 +1,151 @@
-import React from 'react';
-import { View, Text } from 'react-native';
-import { Screen } from '../../components';
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, Pressable } from 'react-native';
+import { Button, Screen } from '../../components';
+import Star from '../../../assets/icons/star.svg';
+import ChevronUp from '../../../assets/icons/chevron-up.svg';
+import ChevronDown from '../../../assets/icons/chevron-down.svg';
+import { colors } from '../../theme/colors';
+import { fonts } from '../../theme/typography';
+import { ProgressBar } from '../../components/ProgressBar';
+
+const REWARD_OPTIONS = [
+  { points: 25, description: 'Customize your drink (espresso shot, nondairy milk, syrup and more)' },
+  { points: 100, description: 'Brewed hot or iced coffee or tea, bakery item, packaged snack and more' },
+  { points: 200, description: 'Handcrafted drink (Cold Brew, lattes and more) or hot breakfast' },
+  { points: 300, description: 'Sandwich, protein box or at-home coffee' },
+  { points: 400, description: 'Select merchandise' },
+];
+
+export const getProgress = (currentPoints: number, maxPoints: number) => {
+  const progress = currentPoints / maxPoints;
+  if (progress < 0 || !isFinite(progress)) {
+    return 0;
+  }
+  return progress > 1 ? 1 : progress;
+};
 
 export const Home = () => {
+  const [showRewardsOptions, setShowRewardsOptions] = useState(false);
+  const rewardsTiers = [25, 100, 200, 300, 400];
+  const maxBalance = 450;
+  const pointsBalance = 150;
+
   return (
     <Screen>
-      <View>
-        <Text>Home</Text>
+      <View style={styles.container}>
+        <View style={styles.temp}>
+          <View>
+            <View style={styles.balance}>
+              <Text style={styles.points}>{pointsBalance}</Text>
+              <Star height={16} width={16} style={styles.star} />
+            </View>
+            <Text style={styles.star_balance}>Star balance</Text>
+          </View>
+          <View>
+            <Pressable style={styles.rewards_options} onPress={() => setShowRewardsOptions(!showRewardsOptions)}>
+              <Text style={styles.rewards_options_text}>Rewards options</Text>
+              {showRewardsOptions ? (
+                <ChevronUp height={15} width={15} color={colors.slate400} />
+              ) : (
+                <ChevronDown height={15} width={15} color={colors.slate400} />
+              )}
+            </Pressable>
+          </View>
+        </View>
+        <ProgressBar progress={getProgress(pointsBalance, maxBalance)} tiers={rewardsTiers} />
+        {showRewardsOptions && (
+          <View style={styles.options}>
+            <Text style={styles.options_title}>Rewards you can get with points</Text>
+            {REWARD_OPTIONS.map((option, index) => {
+              return (
+                <View key={index} style={styles.tier}>
+                  <View style={styles.tier_points_container}>
+                    <Text style={styles.tier_points}>{option.points}</Text>
+                    <Star height={8} width={8} style={styles.tier_star} />
+                  </View>
+                  <Text style={styles.tier_description}>{option.description}</Text>
+                </View>
+              );
+            })}
+          </View>
+        )}
+        <View style={styles.buttons}>
+          <Button text="Details" />
+        </View>
       </View>
     </Screen>
   );
 };
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: 15,
+    marginVertical: 15,
+  },
+  temp: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  balance: {
+    flexDirection: 'row',
+  },
+  points: {
+    fontFamily: fonts.SodoSans.semibold,
+    fontSize: 28,
+  },
+  star: {
+    marginTop: 12,
+  },
+  star_balance: {
+    fontSize: 11,
+    marginBottom: 10,
+  },
+  rewards_options: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: 10,
+  },
+  rewards_options_text: {
+    fontFamily: fonts.SodoSans.regular,
+    fontSize: 11,
+    marginRight: 6,
+  },
+  options_title: {
+    fontFamily: fonts.SodoSans.semibold,
+    fontSize: 15,
+    padding: 10,
+  },
+  options: {
+    backgroundColor: colors.neutral200,
+    borderRadius: 10,
+    marginVertical: 10,
+  },
+  tier: {
+    flex: 1,
+    flexDirection: 'row',
+    marginBottom: 12,
+    marginLeft: 10,
+    width: 'auto',
+  },
+  tier_points_container: {
+    flexDirection: 'row',
+    marginHorizontal: 8,
+    justifyContent: 'flex-end',
+    width: '10%',
+  },
+  tier_points: {
+    fontFamily: fonts.SodoSans.semibold,
+    fontSize: 11,
+  },
+  tier_star: {
+    marginTop: 3,
+  },
+  tier_description: {
+    fontFamily: fonts.SodoSans.regular,
+    fontSize: 11,
+    width: '80%',
+  },
+  buttons: {
+    marginTop: 20,
+  },
+});

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -2,7 +2,8 @@ export const colors = {
   // https://tailwindcss.com/docs/customizing-colors
   slate400: '#94a3b8',
   gray800: '#1f2937',
-
+  neutral200: '#e5e5e5',
+  neutral500: '#737373',
   /*
     Brand colors
     https://creative.starbucks.com/color/


### PR DESCRIPTION
## Description

Added Home screen UI to display current points balance, points progress and expandable rewards level descriptions.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Changes Made

- Updated Button component to add an accessibilityRole property and updated tests accordingly
- Added ProgressBar component that displays completed progress
  - Supports optional tiers property to display levels under progress indicator
- Updated Home screen UI to display
  - Current points balance
  - Points progress bar with rewards levels
  - Pressable Rewards options the shows/hides description of different rewards levels
- Added unit tests for Home screen and ProgressBar component

<img src="https://github.com/israataha/sweet-rewards/assets/20827404/d76294e9-9512-4d9f-a2b8-faf36de1902b" height=350 />

<img src="https://github.com/israataha/sweet-rewards/assets/20827404/3b4b4b0c-983f-403d-989e-ac82ef402b72" height=350 />

# How Has This Been Tested?

- [x] Unit tests
- [x] Integration tests
- [x] Manual tests

# Checklist:

- [x] Code follows the style guidelines of this project
- [x] Code comments have been added, particularly in hard-to-understand areas
- [x] Tests have been added, if applicable
- [x] New and existing unit tests pass locally
- [x] Relevant documentation has been added or updated, if applicable
- [x] Code runs locally and generates no new errors or warnings